### PR TITLE
Unroll slices to avoid garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,12 @@ Use the previously-calculated triangularization to find the vector x that minimi
 - `x` is the input vector of length m. The answer is computed in-place in the first n entries of `x`. The remaining entries are zero.
 
 
+## Benchmarks
+
+```sh
+$ npm run bench
+```
+
+
 ## Credits
 (c) 2015 Ricky Reusser. MIT License

--- a/benchmarks/triangularize.js
+++ b/benchmarks/triangularize.js
@@ -10,6 +10,9 @@ var bench = require('microbench'),
 
 bench.usePlugin('clitable');
 
+bench.set('throwaway iterations', 200);
+bench.set('default iterations', 100);
+
 bench.category('QR factorization',function() {
 
   var m = 150,

--- a/benchmarks/triangularize.js
+++ b/benchmarks/triangularize.js
@@ -3,34 +3,55 @@ var bench = require('microbench'),
     ndarray = require('ndarray'),
     pool = require('ndarray-scratch'),
     fill = require('ndarray-fill'),
-    qr = require('../lib'),
-    qrPreUnroll = require('../historical/pre-unroll'),
+    qrv3 = require('../lib'),
+    qrv2 = require('../historical/v2'),
+    qrv1 = require('../historical/v1'),
     show = require('ndarray-show')
 
 bench.usePlugin('clitable');
 
 bench.category('QR factorization',function() {
 
-  var m = 10001,
-      n = 10 
+  var m = 150,
+      n = 60
 
   bench.fixtures('d', pool.zeros([m],'float64'))
   bench.fixtures('A', pool.zeros([m,n],'float64'))
-  bench.fixtures('triv3',qr.triangularize)
-  bench.fixtures('triv2',qrPreUnroll.triangularize)
+  bench.fixtures('x', pool.zeros([n],'float64'))
+  bench.fixtures('b', pool.zeros([m],'float64'))
+  bench.fixtures('work', pool.zeros([qrv1.workVectorLength(m,n)],'float64'))
+  bench.fixtures('triv3',qrv3.triangularize)
+  bench.fixtures('triv2',qrv2.triangularize)
+  bench.fixtures('triv1',qrv1.triangularize)
+  bench.fixtures('solvev3',qrv3.solve)
+  bench.fixtures('solvev2',qrv2.solve)
+  bench.fixtures('solvev1',qrv1.solve)
 
   bench.perTestFixtures('matrix setup',function(fixtures) {
     fill(fixtures.A,function(i,j) {
       return Math.pow(i/(m-1),j)
     })
+    fill(fixtures.x,function(i) {
+      return 1 + Math.sin(i/n)
+    });
+    fill(fixtures.b,function(i) {
+      return 1 + Math.sin(i/n)
+    });
   })
 
-  bench.test('v2',function(fixtures) {
+  bench.test('Naively implemented algorithm',function(fixtures) {
+    fixtures.triv1(fixtures.A, fixtures.work)
+    fixtures.solvev1(fixtures.A, fixtures.work, fixtures.b, fixtures.x)
+  })
+
+  bench.test('Streamlined algorithm',function(fixtures) {
     fixtures.triv2(fixtures.A, fixtures.d)
+    fixtures.solvev2(fixtures.A, fixtures.d, fixtures.b)
   })
 
-  bench.test('v3',function(fixtures) {
+  bench.test('Streamlined + unrolled algorithm',function(fixtures) {
     fixtures.triv3(fixtures.A, fixtures.d)
+    fixtures.solvev3(fixtures.A, fixtures.d, fixtures.b)
   })
 
 }).run()

--- a/benchmarks/triangularize.js
+++ b/benchmarks/triangularize.js
@@ -1,0 +1,30 @@
+var bench = require('microbench'),
+    vander = require('ndarray-vandermonde'),
+    ndarray = require('ndarray'),
+    pool = require('ndarray-scratch'),
+    fill = require('ndarray-fill'),
+    qr = require('../lib'),
+    show = require('ndarray-show')
+
+bench.usePlugin('clitable');
+
+bench.category('QR factorization',function() {
+
+  var m = 10001,
+      n = 10 
+
+  bench.fixtures('d', pool.zeros([m],'float64'))
+  bench.fixtures('A', pool.zeros([m,n],'float64'))
+  bench.fixtures('triangularize',qr.triangularize)
+
+  bench.perTestFixtures('matrix setup',function(fixtures) {
+    fill(fixtures.A,function(i,j) {
+      return Math.pow(i/(m-1),j)
+    })
+  })
+
+  bench.test('v3',function(fixtures) {
+    fixtures.triangularize(fixtures.A, fixtures.d)
+  })
+
+}).run()

--- a/benchmarks/triangularize.js
+++ b/benchmarks/triangularize.js
@@ -4,6 +4,7 @@ var bench = require('microbench'),
     pool = require('ndarray-scratch'),
     fill = require('ndarray-fill'),
     qr = require('../lib'),
+    qrPreUnroll = require('../historical/pre-unroll'),
     show = require('ndarray-show')
 
 bench.usePlugin('clitable');
@@ -15,7 +16,8 @@ bench.category('QR factorization',function() {
 
   bench.fixtures('d', pool.zeros([m],'float64'))
   bench.fixtures('A', pool.zeros([m,n],'float64'))
-  bench.fixtures('triangularize',qr.triangularize)
+  bench.fixtures('triv3',qr.triangularize)
+  bench.fixtures('triv2',qrPreUnroll.triangularize)
 
   bench.perTestFixtures('matrix setup',function(fixtures) {
     fill(fixtures.A,function(i,j) {
@@ -23,8 +25,12 @@ bench.category('QR factorization',function() {
     })
   })
 
+  bench.test('v2',function(fixtures) {
+    fixtures.triv2(fixtures.A, fixtures.d)
+  })
+
   bench.test('v3',function(fixtures) {
-    fixtures.triangularize(fixtures.A, fixtures.d)
+    fixtures.triv3(fixtures.A, fixtures.d)
   })
 
 }).run()

--- a/historical/v1.js
+++ b/historical/v1.js
@@ -1,0 +1,161 @@
+'use strict';
+
+var blas = require('ndarray-blas-level1'),
+    trsv = require('ndarray-blas-trsv'),
+    pool = require('ndarray-scratch');
+
+//var show = require('ndarray-show');
+
+var triangularize = function triangularize( A, v ) {
+  var i,k,n,m;
+
+  if( A.dimension !== 2 ) {
+    throw new TypeError('triangularize():: dimension of input matrix must be 2.');
+  }
+
+  m = A.shape[0];
+  n = A.shape[1];
+
+  if( m < n ) {
+    throw new TypeError('triangularize():: In input matrix A, number of rows m must be greater than number of column n.');
+  }
+
+  if( v === undefined || (v.shape!==undefined && v.shape[0] < m*n - n*(n-1)/2) ) {
+    throw new TypeError('triangularize():: v must be a vector of length >= m*n-n*(n-1)/2 given A is a matrix of size m x n.');
+  }
+
+  var vlo, x0, sgn, x, nrm, Akmkn, alpha, Akmi;
+
+  for( vlo=0, k=0; k<n; k++ ) {
+
+    // Get this section of the packed output array:
+    x = v.lo(vlo).hi(m-k);
+
+    // v = A[k:m,k]
+    blas.copy( A.pick(null,k).lo(k), x );
+
+    // vk = sign(x1) ||x||_2 e1 + x
+    nrm = blas.nrm2(x);
+    x0 = x.get(0);
+    sgn = x0 < 0 ? -1 : 1;
+    x.set(0, x0 + sgn*nrm);
+
+    // vk = vk / ||vk||_2
+    nrm = blas.nrm2(x);
+    if( nrm === 0 ) return false;
+    blas.scal( 1/nrm, x);
+
+    // A[k:m,k:n] = A[k:n,k:n] - 2 * vk * (vk^* * A[k:m,k:n])
+    
+    // Compute alpha = -2 * vk^* * A[k:m,k:n]:
+    Akmkn = A.lo(k,k);
+
+    for(i=0; i<n-k; i++) {
+      Akmi = Akmkn.pick(null,i);
+      alpha = - 2 * blas.dot(x, Akmi);
+      blas.axpy(alpha, x, Akmi);
+    }
+
+    // Increment the current position in the packed output vector v:
+    vlo += m-k;
+  }
+
+
+  return true;
+};
+
+
+var multiplyByQ = function multiplyByQ ( v, n, x ) {
+  var m, k, vlo, xkm, vk, alpha;
+
+  m = x.shape[0];
+
+  vlo = n*(2*m - n - 1)/2;
+
+  for(k=n-1; k>=0; k--) {
+    xkm = x.lo(k);
+
+    // Get this section of the packed output array:
+    vk = x.lo(k).hi(m-k);
+
+    // calculate -2 * vk' * x[k:m]
+    alpha = - 2 * blas.dot(vk, xkm);
+
+    // Update b[k:m] = b[k:m] - 2 * v * (vk' * b[k:m])
+    blas.axpy( alpha, vk, xkm );
+
+    vlo -= m-k+1;
+  }
+  return true;
+};
+
+var multiplyByQinv = function multiplyByQinv( v, n, b ) {
+  var k,vlo,m,bkm,vk,alpha;
+
+  m = b.shape[0];
+
+  for( vlo=0, k=0; k<n; k++ ) {
+    bkm = b.lo(k);
+
+    // Get this section of the packed output array:
+    vk = v.lo(vlo).hi(m-k);
+
+    // calculate -2 * vk' * b[k:m]
+    alpha = - 2 * blas.dot(vk, bkm);
+
+    // Update b[k:m] = b[k:m] - 2 * v * (vk' * b[k:m])
+    blas.axpy( alpha, vk, bkm );
+
+    // Move to the next section of the packed v array
+    vlo += m-k;
+  }
+
+  return true;
+};
+
+//var constructQ = function( Q, v ) {
+//};
+
+//var factor = function( ) {
+//};
+
+var workVectorLength = function(m,n) {
+  return m*n-n*(n-1)/2;
+};
+
+var workVector = function(m,n,dtype) {
+  console.warn('workVector is deprecated. Please use workVectorLength() and allocate a one-dimensional ndarray of that size instead.')
+  if( dtype === undefined ) {
+    dtype = 'float64';
+  }
+  return pool.zeros([m*n-n*(n-1)/2],dtype);
+};
+
+
+var solve = function( R, v, b, x ) {
+  var m,n;
+
+  if( R.dimension !== 2 ) {
+    throw new TypeError('triangularize():: dimension of input matrix must be 2.');
+  }
+
+  m = R.shape[0];
+  n = R.shape[1];
+
+  multiplyByQinv( v, n, b );
+
+  blas.copy(b.hi(n),x);
+  trsv( R.lo(0,0).hi(n,n), x );
+
+  return true;
+};
+
+
+exports.triangularize = triangularize;
+exports.multiplyByQ = multiplyByQ;
+exports.multiplyByQinv = multiplyByQinv;
+exports.workVectorLength = workVectorLength;
+exports.workVector = workVector;
+//exports.constructQ = constructQ;
+//exports.factor = factor;
+exports.solve = solve;

--- a/historical/v2.js
+++ b/historical/v2.js
@@ -1,0 +1,111 @@
+'use strict'
+
+var blas = require('ndarray-blas-level1'),
+    fill = require('ndarray-fill')
+
+var triangularize = function triangularize( A, d ) {
+  var j,m,n,i, s, ajj, Ajmj, dj, alpha, Ajmi, fak
+
+  if( A.dimension !== 2 ) {
+    throw new TypeError('triangularize():: dimension of input matrix must be 2.')
+  }
+
+  m = A.shape[0]
+  n = A.shape[1]
+
+  if( m < n ) {
+    throw new TypeError('triangularize():: In input matrix A, number of rows m must be greater than number of column n.')
+  }
+
+  for( j=0; j<n; j++ ) {
+    Ajmj = A.pick(null,j).lo(j)
+    s = blas.nrm2(Ajmj)
+    ajj = Ajmj.get(0)
+    dj = ajj > 0 ? -s : s
+    d.set(j,dj)
+    s = Math.sqrt( s * (s + Math.abs(ajj)) )
+    if( s === 0 ) return false
+    Ajmj.set(0,ajj - dj)
+    blas.scal( 1/s, Ajmj)
+
+    for(i=j+1; i<n; i++) {
+      Ajmi = A.pick(null,i).lo(j)
+      s = - blas.dot( Ajmj, Ajmi )
+      blas.axpy( s, Ajmj, Ajmi )
+    }
+  }
+
+  return true
+}
+
+
+var multiplyByQ = function multiplyByQ ( A, b ) {
+  var j, Ajmj, yk, s, n = A.shape[1]
+
+  for(j=n-1; j>=0; j--) {
+    Ajmj = A.pick(null,j).lo(j)
+    yk = b.lo(j)
+    s = -blas.dot(Ajmj,yk)
+    blas.axpy( s, Ajmj, yk)
+  }
+  return true
+}
+
+var multiplyByQinv = function multiplyByQinv( A, b ) {
+  var j, Ajmj, yk, s, n = A.shape[1]
+
+  for(j=0; j<n; j++) {
+    Ajmj = A.pick(null,j).lo(j)
+    yk = b.lo(j)
+    s = -blas.dot(Ajmj,yk)
+    blas.axpy( s, Ajmj, yk)
+  }
+
+  return true
+}
+
+var constructQ = function( QR, Q ) {
+  var j, Qj, n=Q.shape[1]
+
+  fill(Q,function(i,j){ return i===j ? 1 : 0})
+
+  for(j=0; j<n; j++) {
+    Qj = Q.pick(null,j)
+    multiplyByQ( QR, Qj )
+  }
+
+  return true
+}
+
+//var factorize = function( A, Q, R ) {
+//}
+
+
+var solve = function( QR, d, x ) {
+  var m,n, dot = blas.dot
+
+  if( QR.dimension !== 2 ) {
+    throw new TypeError('triangularize():: dimension of input matrix must be 2.')
+  }
+
+  m = QR.shape[0]
+  n = QR.shape[1]
+
+  multiplyByQinv( QR, x )
+
+  // Copied from TRSV, except replacing the diagonal with d:
+  x.set( n-1, x.get(n-1)/d.get(n-1,n-1) )
+  for(var i=n-2; i>=0; i--) {
+    x.set(i, (x.get(i) - dot(QR.pick(i,null).lo(i+1), x.lo(i+1))) / d.get(i) )
+  }
+
+  return true
+}
+
+
+exports.triangularize = triangularize
+exports.multiplyByQ = multiplyByQ
+exports.multiplyByQinv = multiplyByQinv
+exports.constructQ = constructQ
+//exports.factorize = factorize
+exports.solve = solve

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,17 @@
 
 var blas = require('ndarray-blas-level1'),
     fill = require('ndarray-fill')
+    //ndshow = require('ndarray-show')
+
+/*function show(label,data) {
+  if( typeof data === 'number' ) {
+    console.log(label+' = '+data)
+  } else if( data.dimension === 1 ) {
+    console.log(label+' = '+ndshow(data))
+  } else {
+    console.log(label+' =\n'+ndshow(data.transpose(1,0))+'\n')
+  }
+}*/
 
 var triangularize = function triangularize( A, d ) {
   var j,m,n,i, s, ajj, Ajmj, dj, alpha, Ajmi, fak
@@ -17,19 +28,26 @@ var triangularize = function triangularize( A, d ) {
     throw new TypeError('triangularize():: In input matrix A, number of rows m must be greater than number of column n.')
   }
 
-  for( j=0; j<n; j++ ) {
-    Ajmj = A.pick(null,j).lo(j)
+  Ajmj = A.pick(null,0)
+  Ajmi = A.pick(null,0)
+  var AjmiOff = Ajmi.offset
+  var AjmjInc = A.stride[0] + A.stride[1]
+  var AjmiInc1 = A.stride[0]
+  var AjmiInc2 = A.stride[1]
+  var dInc = d.stride[0]
+  var dOff = d.offset
+
+  for( j=0; j<n; j++, Ajmj.shape[0]--, Ajmj.offset+=AjmjInc, AjmiOff+=AjmiInc1, dOff+=dInc) {
     s = blas.nrm2(Ajmj)
-    ajj = Ajmj.get(0)
+    ajj = Ajmj.data[Ajmj.offset]
     dj = ajj > 0 ? -s : s
-    d.set(j,dj)
+    d.data[dOff] = dj
     s = Math.sqrt( s * (s + Math.abs(ajj)) )
     if( s === 0 ) return false
-    Ajmj.set(0,ajj - dj)
+    Ajmj.data[Ajmj.offset] = ajj - dj
     blas.scal( 1/s, Ajmj)
 
-    for(i=j+1; i<n; i++) {
-      Ajmi = A.pick(null,i).lo(j)
+    for(i=j+1, Ajmi.offset=AjmiOff + AjmiInc2*(j+1); i<n; i++, Ajmi.offset+=AjmiInc2) {
       s = - blas.dot( Ajmj, Ajmi )
       blas.axpy( s, Ajmj, Ajmi )
     }
@@ -40,36 +58,44 @@ var triangularize = function triangularize( A, d ) {
 
 
 var multiplyByQ = function multiplyByQ ( A, b ) {
-  var j, Ajmj, yk, s, n = A.shape[1]
+  var j, Ajmj, yk, n=A.shape[1], m=A.shape[0]
 
-  for(j=n-1; j>=0; j--) {
-    Ajmj = A.pick(null,j).lo(j)
-    yk = b.lo(j)
-    s = -blas.dot(Ajmj,yk)
-    blas.axpy( s, Ajmj, yk)
+  Ajmj = A.pick(null,n-1).lo(n-1)
+  yk = b.lo(n-1)
+
+  var AjmjOffInc = A.stride[0] + A.stride[1]
+  var ykInc = yk.stride[0]
+
+  for(j=n-1; j>=0; j--, Ajmj.offset-=AjmjOffInc, Ajmj.shape[0]++, yk.offset-=ykInc, yk.shape[0]++ ) {
+    blas.axpy( -blas.dot(Ajmj,yk), Ajmj, yk)
   }
+
   return true
 }
+//console.log('i='+j,'shape=',Ajmj.shape,'stride=',Ajmj.stride,'offset=',Ajmj.offset)
 
 var multiplyByQinv = function multiplyByQinv( A, b ) {
-  var j, Ajmj, yk, s, n = A.shape[1]
+  var j, Ajmj, yk, n=A.shape[1], m=A.shape[0]
 
-  for(j=0; j<n; j++) {
-    Ajmj = A.pick(null,j).lo(j)
-    yk = b.lo(j)
-    s = -blas.dot(Ajmj,yk)
-    blas.axpy( s, Ajmj, yk)
+  Ajmj = A.pick(null,0).lo(0)
+  yk = b.lo(0)
+
+  var AjmjOffInc = A.stride[0] + A.stride[1]
+  var ykInc = yk.stride[0]
+
+  for(j=0; j<n; j++, Ajmj.offset+=AjmjOffInc, Ajmj.shape[0]--, yk.offset+=ykInc, yk.shape[0]--) {
+    blas.axpy( -blas.dot(Ajmj,yk), Ajmj, yk)
   }
 
   return true
 }
 
 var constructQ = function( QR, Q ) {
-  var j, Qj, n=Q.shape[1]
+  var j, Qj, n=Q.shape[1], m=Q.shape[0]
 
   fill(Q,function(i,j){ return i===j ? 1 : 0})
 
-  for(j=0; j<n; j++) {
+  for(j=0; j<n; j++ ) {
     Qj = Q.pick(null,j)
     multiplyByQ( QR, Qj )
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
 var blas = require('ndarray-blas-level1'),
+    ops = require('ndarray-ops'),
+    diag = require('ndarray-diagonal'),
     fill = require('ndarray-fill')
     //ndshow = require('ndarray-show')
 
@@ -34,10 +36,11 @@ var triangularize = function triangularize( A, d ) {
   var AjmjInc = A.stride[0] + A.stride[1]
   var AjmiInc1 = A.stride[0]
   var AjmiInc2 = A.stride[1]
+  var AjmjShape = Ajmj.shape
   var dInc = d.stride[0]
   var dOff = d.offset
 
-  for( j=0; j<n; j++, Ajmj.shape[0]--, Ajmj.offset+=AjmjInc, AjmiOff+=AjmiInc1, dOff+=dInc) {
+  for( j=0; j<n; j++, AjmjShape[0]--, Ajmj.offset+=AjmjInc, AjmiOff+=AjmiInc1, dOff+=dInc) {
     s = blas.nrm2(Ajmj)
     ajj = Ajmj.data[Ajmj.offset]
     dj = ajj > 0 ? -s : s
@@ -47,7 +50,7 @@ var triangularize = function triangularize( A, d ) {
     Ajmj.data[Ajmj.offset] = ajj - dj
     blas.scal( 1/s, Ajmj)
 
-    for(i=j+1, Ajmi.offset=AjmiOff + AjmiInc2*(j+1); i<n; i++, Ajmi.offset+=AjmiInc2) {
+    for(i=j+1, Ajmi.offset=AjmiOff + AjmiInc2*i; i<n; i++, Ajmi.offset+=AjmiInc2) {
       s = - blas.dot( Ajmj, Ajmi )
       blas.axpy( s, Ajmj, Ajmi )
     }
@@ -64,9 +67,11 @@ var multiplyByQ = function multiplyByQ ( A, b ) {
   yk = b.lo(n-1)
 
   var AjmjOffInc = A.stride[0] + A.stride[1]
+  var AjmjShape = Ajmj.shape
   var ykInc = yk.stride[0]
+  var ykShape = yk.shape
 
-  for(j=n-1; j>=0; j--, Ajmj.offset-=AjmjOffInc, Ajmj.shape[0]++, yk.offset-=ykInc, yk.shape[0]++ ) {
+  for(j=n-1; j>=0; j--, Ajmj.offset-=AjmjOffInc, AjmjShape[0]++, yk.offset-=ykInc, ykShape[0]++ ) {
     blas.axpy( -blas.dot(Ajmj,yk), Ajmj, yk)
   }
 
@@ -81,9 +86,11 @@ var multiplyByQinv = function multiplyByQinv( A, b ) {
   yk = b.lo(0)
 
   var AjmjOffInc = A.stride[0] + A.stride[1]
+  var AjmjShape = Ajmj.shape
   var ykInc = yk.stride[0]
+  var ykShape = yk.shape
 
-  for(j=0; j<n; j++, Ajmj.offset+=AjmjOffInc, Ajmj.shape[0]--, yk.offset+=ykInc, yk.shape[0]--) {
+  for(j=0; j<n; j++, Ajmj.offset+=AjmjOffInc, AjmjShape[0]--, yk.offset+=ykInc, ykShape[0]--) {
     blas.axpy( -blas.dot(Ajmj,yk), Ajmj, yk)
   }
 
@@ -93,10 +100,14 @@ var multiplyByQinv = function multiplyByQinv( A, b ) {
 var constructQ = function( QR, Q ) {
   var j, Qj, n=Q.shape[1], m=Q.shape[0]
 
-  fill(Q,function(i,j){ return i===j ? 1 : 0})
 
-  for(j=0; j<n; j++ ) {
-    Qj = Q.pick(null,j)
+  ops.assigns(Q,0)
+  ops.assigns(diag(Q),1)
+
+  var Qj = Q.pick(null,0)
+  var QjInc = Q.stride[1]
+
+  for(j=0; j<n; j++, Qj.offset+=QjInc ) {
     multiplyByQ( QR, Qj )
   }
 
@@ -108,7 +119,7 @@ var constructQ = function( QR, Q ) {
 
 
 var solve = function( QR, d, x ) {
-  var m,n, dot = blas.dot
+  var m,n,j,QRi, QRi, QRiInc, QRiShape, dot=blas.dot, xj, xjInc, xjShape, xInc, xPos, dPos, dInc, xData, dData, dPos, dInc
 
   if( QR.dimension !== 2 ) {
     throw new TypeError('triangularize():: dimension of input matrix must be 2.')
@@ -119,10 +130,29 @@ var solve = function( QR, d, x ) {
 
   multiplyByQinv( QR, x )
 
-  // Copied from TRSV, except replacing the diagonal with d:
-  x.set( n-1, x.get(n-1)/d.get(n-1,n-1) )
-  for(var i=n-2; i>=0; i--) {
-    x.set(i, (x.get(i) - dot(QR.pick(i,null).lo(i+1), x.lo(i+1))) / d.get(i) )
+  QRi = QR.pick(n-2,null).lo(n-1)
+  QRiInc = QR.stride[1] + QR.stride[0]
+  QRiShape = QRi.shape
+
+  xj = x.lo(n-1)
+  xjInc = x.stride[0]
+  xjShape = xj.shape
+
+  xPos = x.offset + x.stride[0]*(n-1)
+  xInc = x.stride[0]
+  xData = x.data
+
+  dPos = d.offset + d.stride[0]*(n-1)
+  dInc = d.stride[0]
+  dData = d.data
+
+  xData[xPos] = xData[xPos] / dData[dPos]
+
+  for(j=n-2, xPos-=xInc, dPos -= dInc;
+      j>=0;
+      j--, QRi.offset-=QRiInc, QRiShape[0]+=1, xjShape[0]++, xj.offset-=xjInc, xPos-=xInc, dPos-=dInc ) {
+
+    xData[xPos] = (xData[xPos] - dot(QRi, xj)) / dData[dPos]
   }
 
   return true

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,7 +150,7 @@ var solve = function( QR, d, x ) {
 
   for(j=n-2, xPos-=xInc, dPos -= dInc;
       j>=0;
-      j--, QRi.offset-=QRiInc, QRiShape[0]+=1, xjShape[0]++, xj.offset-=xjInc, xPos-=xInc, dPos-=dInc ) {
+      j--, QRi.offset-=QRiInc, QRiShape[0]++, xjShape[0]++, xj.offset-=xjInc, xPos-=xInc, dPos-=dInc ) {
 
     xData[xPos] = (xData[xPos] - dot(QRi, xj)) / dData[dPos]
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "mocha",
-    "lint": "jshint **.js"
+    "lint": "jshint **.js",
+    "bench": "node benchmarks/*.js"
   },
   "keywords": [
     "householder",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "chai": "*",
     "jshint": "*",
+    "microbench": "../microbench",
     "mocha": "*",
     "ndarray": "^1.0.16",
     "ndarray-scratch": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "ndarray-blas-level1": "^1.0.0",
-    "ndarray-fill": "^1.0.1"
+    "ndarray-diagonal": "^1.0.0",
+    "ndarray-fill": "^1.0.1",
+    "ndarray-ops": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "devDependencies": {
     "chai": "*",
     "jshint": "*",
-    "microbench": "../microbench",
+    "microbench": "git+https://rreusser@github.com/rreusser/microbench.git",
     "mocha": "*",
     "ndarray": "^1.0.16",
+    "ndarray-blas-trsv": "^1.0.1",
     "ndarray-scratch": "^1.1.1",
     "ndarray-show": "^1.1.1",
     "ndarray-tests": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ndarray-householder-qr",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Householder triangularization for QR Factorization of ndarrays",
   "main": "lib/index.js",
   "author": "Ricky Reusser",

--- a/test/test.js
+++ b/test/test.js
@@ -178,8 +178,10 @@ describe("Householder QR with complicated slices", function() {
     A = pool.zeros([60,80,90]).pick(null,null,14).lo(15,19).step(8,10).hi(m,n)
     blas.copy( Acontent, A )
 
-    Q = pool.zeros([m,m])
-    Qreduced = pool.zeros([m,n])
+    var Qbase = pool.zeros([80,40])
+    Q = Qbase.lo(4,17).step(4,3).hi(m,m)
+    var QreducedBase = pool.zeros([17,22])
+    Qreduced = QreducedBase.lo(2,3).step(3,2).hi(m,n)
     d = pool.zeros([14,3,12]).pick(3,2,null).lo(1).hi(n)
     var bContent = ndarray([1,2,3,4,5,6])
     b = pool.zeros([17,8,12]).pick(3,null,4).lo(2).hi(m)
@@ -230,7 +232,38 @@ describe("Householder QR with complicated slices", function() {
 
       assert( ndtest.approximatelyEqual( QbExpected, x, 1e-3 ) )
     })
+  })
+
+  describe("constructQ()", function() {
+
+    beforeEach(function() {
+      householder.triangularize(A,d)
+    })
+
+    it('calculates Q for the full QR factorization',function(){
+      assert( householder.constructQ(A,Q) )
+      assert( ndtest.matrixOrthogonal(Q,1e-3) )
+    })
+
+    it('calculates Q for the reduced QR factorization',function(){
+      assert( householder.constructQ(A,Qreduced) )
+      assert( ndtest.matrixColsNormalized(Qreduced,1e-3) )
+      assert( ndtest.matrixColsAreOrthogonal(Qreduced,1e-3) )
+    })
+
 
   })
+
+  describe("solve()", function() {
+    it('calculates the right answer',function() {
+      var xExpected = ndarray([1,1,0,0,0,0])
+
+      householder.triangularize(A,d)
+      householder.solve(A,d,b)
+
+      assert( ndtest.approximatelyEqual( xExpected, b, 1e-4 ) )
+    })
+  })
+
 
 })


### PR DESCRIPTION
@mikolalysenko — I was curious how I might optimize these linear algebra routines, so I tried out unrolling the slices so that it doesn't instantiate new ndarray slices on every inner loop iteration. Instead, it just calculates a single slice at the beginning and increments the offset. (I also just set `*.data[…]` directly in some spots since `.set(0,…)` is trivial — although this certainly doesn't amount to any significant speedup). I added tests using slices of high-dimensional arrays with weird steps as input, so I'm reasonably confident in the correctness. The result is significantly less maintainable but avoids lots of object allocation/garbage collection.

**Question**: I'll profile to see if it has any affect, but at a glance, do you think this is a remotely reasonable approach once things have been developed and tested? I feel like the original version should be saved so that it's clear where this madness came from. It's basically the sort of thing cwise does, just by hand…

Here's an example:

``` javascript
  // Instantiate a single slice at the beginning:
  Ajmj = A.pick(null,0)
  Ajmi = A.pick(null,0)

  // Figure out the offsets and increments:
  var AjmjInc = A.stride[0] + A.stride[1]
  var AjmiOff = Ajmi.offset
  var AjmiInc1 = A.stride[0]
  var AjmiInc2 = A.stride[1]
  var dInc = d.stride[0]
  var dOff = d.offset

  for( j=0; j<n; j++, Ajmj.shape[0]--, Ajmj.offset+=AjmjInc, AjmiOff+=AjmiInc1, dOff+=dInc) {
    s = blas.nrm2(Ajmj)
    ajj = Ajmj.data[Ajmj.offset]
    dj = ajj > 0 ? -s : s 
    d.data[dOff] = dj
    s = Math.sqrt( s * (s + Math.abs(ajj)) )
    if( s === 0 ) return false
    Ajmj.data[Ajmj.offset] = ajj - dj
    blas.scal( 1/s, Ajmj)

    for(i=j+1, Ajmi.offset=AjmiOff + AjmiInc2*(j+1); i<n; i++, Ajmi.offset+=AjmiInc2) {
      s = - blas.dot( Ajmj, Ajmi )
      blas.axpy( s, Ajmj, Ajmi )
    }   
  }

  return true
}
```
